### PR TITLE
fix(shipment): Changed ShipmentProvider Delete

### DIFF
--- a/api/providers/ShipmentProvider.cs
+++ b/api/providers/ShipmentProvider.cs
@@ -51,9 +51,9 @@ public class ShipmentProvider : BaseProvider<Shipment>
 
     public override Shipment? Delete(Guid id)
     {
-        Shipment? foundShipment = _db.Shipments.FirstOrDefault(s => s.Id == id);
+        Shipment? foundShipment = GetById(id);
         if(foundShipment == null) return null;
-        
+
         _db.Shipments.Remove(foundShipment);
         SaveToDBOrFail();
         return foundShipment;


### PR DESCRIPTION
# Issue
https://project-hr.atlassian.net/browse/INFSCP01-197

## Description
In de Delete function binnen de ShipmentProvider was er een probleem vanwege Lazy Loading dat C# de relatie tussen Shipment en ShipmentItems niet correct meegaf, met GetById is dit opgelost aangezien deze functie direct alles ophaalt van de DB.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Steps to Test
Outline the steps to test or reproduce the PR here.

1. Voer een delete uit van een shipment via de .rest file