### PR TITLE
Infscp01 80 feature get all orders from shipment

### DIFF
--- a/api/Controllers/ShipmentsController.cs
+++ b/api/Controllers/ShipmentsController.cs
@@ -1,4 +1,5 @@
 using DTO.Shipment;
+using DTO.Order;
 using Microsoft.AspNetCore.Mvc;
 
 [Route("api/[controller]")]
@@ -142,8 +143,37 @@ public class ShipmentsController : ControllerBase
     }
 
     [HttpGet("{id}/orders")]
-    public IActionResult ShowOrders(Guid id)
+    public IActionResult GetOrdersForShipment(Guid id)
     {
-        return null;
+        var orders = _shipmentProvider.GetOrdersForShipment(id);
+
+        if (orders == null || !orders.Any())
+            return NotFound(new { Message = "No orders found for the specified shipment." });
+
+        var response = orders.Select(o => new OrderResponse
+        {
+            Id = o.Id,
+            OrderDate = o.OrderDate,
+            RequestDate = o.RequestDate,
+            Reference = o.Reference,
+            ReferenceExtra = o.ReferenceExtra,
+            OrderStatus = o.OrderStatus,
+            Notes = o.Notes,
+            PickingNotes = o.PickingNotes,
+            TotalAmount = o.TotalAmount,
+            TotalDiscount = o.TotalDiscount,
+            TotalTax = o.TotalTax,
+            TotalSurcharge = o.TotalSurcharge,
+            WarehouseId = o.WarehouseId,
+            CreatedAt = o.CreatedAt,
+            UpdatedAt = o.UpdatedAt,
+            Items = o.OrderItems?.Select(oi => new OrderItemRequest
+            {
+                ItemId = oi.ItemId,
+                Amount = oi.Amount
+            }).ToList()
+        }).ToList();
+
+        return Ok(response);
     }
 }

--- a/api/Controllers/ShipmentsController.cs
+++ b/api/Controllers/ShipmentsController.cs
@@ -22,7 +22,7 @@ public class ShipmentsController : ControllerBase
         return Ok(new ShipmentResponse
         {
             Id = newShipment.Id,
-            OrderId = newShipment.OrderId,
+            OrderIds = newShipment.OrderIds,
             OrderDate = newShipment.OrderDate,
             RequestDate = newShipment.RequestDate,
             ShipmentDate = newShipment.ShipmentDate,
@@ -56,7 +56,7 @@ public class ShipmentsController : ControllerBase
             message = "Shipment deleted!",
             deleted_shipment = new ShipmentResponse{
             Id = deletedShipment.Id,
-            OrderId = deletedShipment.OrderId,
+            OrderIds = deletedShipment.OrderIds,
             OrderDate = deletedShipment.OrderDate,
             RequestDate = deletedShipment.RequestDate,
             ShipmentDate = deletedShipment.ShipmentDate,
@@ -84,7 +84,7 @@ public class ShipmentsController : ControllerBase
     public IActionResult ShowAll() => Ok(_shipmentProvider.GetAll()?.Select(s => new ShipmentResponse
     {
         Id = s.Id,
-        OrderId = s.OrderId,
+        OrderIds = s.OrderIds,
         OrderDate = s.OrderDate,
         RequestDate = s.RequestDate,
         ShipmentDate = s.ShipmentDate,
@@ -117,7 +117,7 @@ public class ShipmentsController : ControllerBase
             : Ok(new ShipmentResponse
             {        
                 Id = foundShipment.Id,
-                OrderId = foundShipment.OrderId,
+                OrderIds = foundShipment.OrderIds,
                 OrderDate = foundShipment.OrderDate,
                 RequestDate = foundShipment.RequestDate,
                 ShipmentDate = foundShipment.ShipmentDate,
@@ -139,5 +139,11 @@ public class ShipmentsController : ControllerBase
                     Amount = item.Amount
                 }).ToList()
         });
+    }
+
+    [HttpGet("{id}/orders")]
+    public IActionResult ShowOrders(Guid id)
+    {
+        return null;
     }
 }

--- a/api/DTOs/shipment/ShipmentDTO.cs
+++ b/api/DTOs/shipment/ShipmentDTO.cs
@@ -8,7 +8,7 @@ namespace DTO.Shipment
     public class ShipmentRequest : BaseDTO
     {
         [JsonPropertyName("order_ids")]
-        public Guid? OrderIds { get; set; }
+        public List<Guid?> OrderIds { get; set; }
 
         [JsonPropertyName("order_date")]
         public DateTime? OrderDate { get; set; }
@@ -74,7 +74,7 @@ namespace DTO.Shipment
         public Guid Id { get; set; }
 
         [JsonPropertyName("order_ids")]
-        public Guid? OrderIds { get; set; }
+        public List<Guid?> OrderIds { get; set; }
 
         [JsonPropertyName("order_date")]
         public DateTime? OrderDate { get; set; }

--- a/api/DTOs/shipment/ShipmentDTO.cs
+++ b/api/DTOs/shipment/ShipmentDTO.cs
@@ -7,8 +7,8 @@ namespace DTO.Shipment
     [ApiExplorerSettings(IgnoreApi = true)]
     public class ShipmentRequest : BaseDTO
     {
-        [JsonPropertyName("order_id")]
-        public Guid? OrderId { get; set; }
+        [JsonPropertyName("order_ids")]
+        public Guid? OrderIds { get; set; }
 
         [JsonPropertyName("order_date")]
         public DateTime? OrderDate { get; set; }
@@ -73,8 +73,8 @@ namespace DTO.Shipment
         [JsonPropertyName("id")]
         public Guid Id { get; set; }
 
-        [JsonPropertyName("order_id")]
-        public Guid? OrderId { get; set; }
+        [JsonPropertyName("order_ids")]
+        public Guid? OrderIds { get; set; }
 
         [JsonPropertyName("order_date")]
         public DateTime? OrderDate { get; set; }

--- a/api/Rest/Shipments/.rest
+++ b/api/Rest/Shipments/.rest
@@ -3,21 +3,22 @@ POST http://localhost:5000/api/shipments
 Content-Type: application/json
 
 {
-  "order_date": "2023-11-19T14:12:33.807Z",
+  "order_ids": ["4f82da38-7048-4c70-b7d6-e89c3752e094", "6a04d058-d3cf-4174-9663-7a5e8413d57d"],
   "request_date": "2024-11-19T14:12:33.807Z",
   "shipment_date": "2024-11-19T14:12:33.807Z",
-  "shipment_status": "Delivered",
+  "shipment_type": "I",
+  "shipment_status": "Deliverd",
   "notes": "geen notities",
   "carrier_code": "123",
   "carrier_description": "description",
   "service_code": "321",
-  "payment_type": "IDeal",
-  "transfer_mode": "I",
+  "payment_type": "Automatic",
+  "transfer_mode": "Air",
   "total_package_count": 3,
   "total_package_weight": 3.4,
   "items": [
     {
-      "item_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "item_id": "389a0b1a-c7da-4ad8-8aeb-972af2829c9d",
       "amount": 2
     }
   ]
@@ -39,4 +40,8 @@ Content-Type: application/json
 
 ### GET SHIPMENT BY ID (change ID to existing ID in your database)
 GET http://localhost:5000/api/shipments/85e299a8-71e3-4c6b-baf5-d0112129a8c5
+Content-Type: application/json
+
+### GET ALL ORDERS FOR SHIPMENT (change ID to existing ID in your database)
+GET http://localhost:5000/api/shipments/a92e175c-b8be-4582-8600-6d8af394c90a/orders
 Content-Type: application/json

--- a/api/Validators/ShipmentValidator.cs
+++ b/api/Validators/ShipmentValidator.cs
@@ -4,15 +4,21 @@ public class ShipmentValidator : AbstractValidator<Shipment>
 {
     public ShipmentValidator(AppDbContext db)
     {
-        RuleFor(shipment => shipment.OrderId)
-            .NotNull().WithMessage("order_id is required.")
-            .NotEmpty().WithMessage("order_id cannot be empty.")
-            .Custom((orderId, context) =>
+        RuleFor(shipment => shipment.OrderIds)
+            .NotNull().WithMessage("order_ids are required.")
+            .NotEmpty().WithMessage("order_ids cannot be empty.")
+            .ForEach(orderIdRule =>
             {
-                if (orderId != null && !db.Orders.Any(o => o.Id == orderId))
-                {
-                    context.AddFailure("order_id", "The provided order_id does not exist.");
-                }
+                orderIdRule
+                    .NotNull().WithMessage("Each order_id is required.")
+                    .NotEmpty().WithMessage("Each order_id cannot be empty.")
+                    .Custom((orderId, context) =>
+                    {
+                        if (orderId != null && !db.Orders.Any(o => o.Id == orderId))
+                        {
+                            context.AddFailure("order_id", $"The provided order_id '{orderId}' does not exist.");
+                        }
+                    });
             });
         RuleFor(shipment => shipment.ShipmentType)
             .NotNull().WithMessage("shipment_type is required.")

--- a/api/models/Shipment.cs
+++ b/api/models/Shipment.cs
@@ -7,7 +7,7 @@ public class Shipment : BaseModel
     public Shipment(bool newInstance = false, bool isUpdate = false) : base(newInstance, isUpdate) { }
 
     [Required]
-    public List<Guid> OrderIds { get; set; }
+    public List<Guid?> OrderIds { get; set; }
     public DateTime? OrderDate { get; set; }
     public DateTime? RequestDate { get; set; }
     public DateTime? ShipmentDate { get; set; }

--- a/api/models/Shipment.cs
+++ b/api/models/Shipment.cs
@@ -5,8 +5,6 @@ public class Shipment : BaseModel
 {
     public Shipment() { }
     public Shipment(bool newInstance = false, bool isUpdate = false) : base(newInstance, isUpdate) { }
-
-    [Required]
     public List<Guid?> OrderIds { get; set; }
     public DateTime? OrderDate { get; set; }
     public DateTime? RequestDate { get; set; }

--- a/api/models/Shipment.cs
+++ b/api/models/Shipment.cs
@@ -7,7 +7,7 @@ public class Shipment : BaseModel
     public Shipment(bool newInstance = false, bool isUpdate = false) : base(newInstance, isUpdate) { }
 
     [Required]
-    public Guid? OrderId { get; set; }
+    public Guid? OrderIds { get; set; }
     public DateTime? OrderDate { get; set; }
     public DateTime? RequestDate { get; set; }
     public DateTime? ShipmentDate { get; set; }

--- a/api/models/Shipment.cs
+++ b/api/models/Shipment.cs
@@ -7,7 +7,7 @@ public class Shipment : BaseModel
     public Shipment(bool newInstance = false, bool isUpdate = false) : base(newInstance, isUpdate) { }
 
     [Required]
-    public Guid? OrderIds { get; set; }
+    public List<Guid> OrderIds { get; set; }
     public DateTime? OrderDate { get; set; }
     public DateTime? RequestDate { get; set; }
     public DateTime? ShipmentDate { get; set; }

--- a/api/providers/ShipmentProvider.cs
+++ b/api/providers/ShipmentProvider.cs
@@ -63,7 +63,7 @@ public class ShipmentProvider : BaseProvider<Shipment>
 
     public List<Order>? GetOrdersForShipment(Guid shipmentId)
     {
-        var shipment = _db.Shipments.Include(s => s.OrderIds).FirstOrDefault(s => s.Id == shipmentId);
+        var shipment = _db.Shipments.FirstOrDefault(s => s.Id == shipmentId);
 
         if (shipment == null || shipment.OrderIds == null || !shipment.OrderIds.Any())
             return new List<Order>();

--- a/api/providers/ShipmentProvider.cs
+++ b/api/providers/ShipmentProvider.cs
@@ -61,5 +61,18 @@ public class ShipmentProvider : BaseProvider<Shipment>
         return foundShipment;
     }
 
+    public List<Order>? GetOrdersForShipment(Guid shipmentId)
+    {
+        var shipment = _db.Shipments.Include(s => s.OrderIds).FirstOrDefault(s => s.Id == shipmentId);
+
+        if (shipment == null || shipment.OrderIds == null || !shipment.OrderIds.Any())
+            return new List<Order>();
+
+        return _db.Orders
+            .Include(o => o.OrderItems)
+            .Where(o => shipment.OrderIds.Contains(o.Id))
+            .ToList();
+    }
+
     protected override void ValidateModel(Shipment model) => _shipmentValidator.ValidateAndThrow(model);
 }

--- a/api/providers/ShipmentProvider.cs
+++ b/api/providers/ShipmentProvider.cs
@@ -23,7 +23,7 @@ public class ShipmentProvider : BaseProvider<Shipment>
 
         Shipment newShipment = new Shipment(newInstance: true)
         {
-            OrderId = req.OrderId,
+            OrderIds = req.OrderIds,
             OrderDate = req.OrderDate,
             RequestDate = req.RequestDate,
             ShipmentDate = req.ShipmentDate,


### PR DESCRIPTION
# Issue
https://project-hr.atlassian.net/browse/INFSCP01-80

## Description
Het is nu mogelijk om alle orders op te halen van een specifieke shipment. Het maken van een shipment werkt nu op basis van order_ids, deze mogen null zijn of je geeft een list aan order_ids mee. Zoals "order_ids": ["GUID", "GUID"].

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Steps to Test
Outline the steps to test or reproduce the PR here.

1. Maak een shipment aan met de order_id die bestaat in je DB
2. Pak die ID van de shipment en voer in de rest file de endpoint met /orders uit bij shipment
3. Controleer of alle orders terugkomen die aan die shipment gekoppeld zijn