### PR TITLE
Get item line by id

### DIFF
--- a/api/Controllers/ItemLinesController.cs
+++ b/api/Controllers/ItemLinesController.cs
@@ -31,4 +31,21 @@ public class ItemLinesController : ControllerBase
             }
         });
     }
+
+    [HttpGet("{id}")]
+    public IActionResult ShowSingle(Guid id)
+    {
+        ItemLine? foundItemLine = _itemLinesProvider.GetById(id);
+
+        return (foundItemLine == null)
+            ? NotFound(new { message = $"Item Line not found for id '{id}'" })
+            : Ok(new ItemLineResponse
+            {
+                Id = foundItemLine.Id,
+                Name = foundItemLine.Name,
+                Description = foundItemLine.Description,
+                CreatedAt = foundItemLine.CreatedAt,
+                UpdatedAt = foundItemLine.UpdatedAt
+            });
+    }
 }

--- a/api/REST/ItemLines/.rest
+++ b/api/REST/ItemLines/.rest
@@ -7,3 +7,8 @@ Content-Type: application/json
     "description": "1"
 }
 ###
+
+### GET ITEM LINE BY ID
+GET http://localhost:5000/api/itemlines/04ccd936-c43b-4568-aa5a-b23093c0b8d8
+Content-Type: application/json
+###

--- a/api/providers/ItemLinesProvider.cs
+++ b/api/providers/ItemLinesProvider.cs
@@ -10,6 +10,8 @@ public class ItemLinesProvider : BaseProvider<ItemLine>
         _itemLineValidator = validator;
     }
 
+    public override ItemLine? GetById(Guid id) => _db.ItemLines.FirstOrDefault(il => il.Id == id);
+
     public override ItemLine? Create(BaseDTO createValues)
     {
         ItemLineRequest? req = createValues as ItemLineRequest;


### PR DESCRIPTION
# Issue
https://project-hr.atlassian.net/browse/INFSCP01-58

## Description
Het is nu mogelijk om een item line op te halen op basis van het id bij /itemlines/{id}

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Steps to Test
Outline the steps to test or reproduce the PR here.

1. Run de GET by id in de .REST met de gegeven ID van de item line die je hebt in je DB bij item lines