### PR TITLE
Infscp01 68 feature get item type by id

### DIFF
--- a/api/Controllers/ItemTypesController.cs
+++ b/api/Controllers/ItemTypesController.cs
@@ -31,4 +31,21 @@ public class ItemTypesController : ControllerBase
             }
         });
     }
+
+    [HttpGet("{id}")]
+    public IActionResult ShowSingle(Guid id)
+    {
+        ItemType? foundItemType = _itemTypesProvider.GetById(id);
+
+        return (foundItemType == null)
+            ? NotFound(new { message = $"Item Type not found for id '{id}'" })
+            : Ok(new ItemTypeResponse
+            {
+                Id = foundItemType.Id,
+                Name = foundItemType.Name,
+                Description = foundItemType.Description,
+                CreatedAt = foundItemType.CreatedAt,
+                UpdatedAt = foundItemType.UpdatedAt
+            });
+    }
 }

--- a/api/REST/ItemTypes/.rest
+++ b/api/REST/ItemTypes/.rest
@@ -7,3 +7,8 @@ Content-Type: application/json
     "description": "1"
 }
 ###
+
+### GET ITEM TYPE BY ID
+GET http://localhost:5000/api/itemtypes/caf0c9e3-0266-4ece-800d-cf4a101f0f69
+Content-Type: application/json
+###

--- a/api/providers/ItemTypesProvider.cs
+++ b/api/providers/ItemTypesProvider.cs
@@ -10,6 +10,8 @@ public class ItemTypesProvider : BaseProvider<ItemType>
         _itemTypeValidator = validator;
     }
 
+    public override ItemType? GetById(Guid id) => _db.ItemTypes.FirstOrDefault(it => it.Id == id);
+
     public override ItemType? Create(BaseDTO createValues)
     {
         ItemTypeRequest? req = createValues as ItemTypeRequest;


### PR DESCRIPTION
# Issue
https://project-hr.atlassian.net/browse/INFSCP01-68

## Description
Het is nu mogelijk om een item type te krijgen via een ID, /itemtypes/{id}

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Steps to Test
Outline the steps to test or reproduce the PR here.

1. Run de get by id in de .REST file van item types met een ID die in je DB aanwezig is.