### PR TITLE
Infscp01 30 feature delete item type

### DIFF
--- a/api/Controllers/ItemTypesController.cs
+++ b/api/Controllers/ItemTypesController.cs
@@ -32,6 +32,24 @@ public class ItemTypesController : ControllerBase
         });
     }
 
+    [HttpDelete("{id}")]
+    public IActionResult Delete(Guid id)
+    {
+        ItemType? deletedItemType = _itemTypesProvider.Delete(id);
+        if (deletedItemType == null) throw new ApiFlowException($"Item Type not found for id '{id}'");
+
+        return Ok(new {
+            message = "Item Type deleted!",
+            deleted_item_type = new ItemTypeResponse{
+            Id = deletedItemType.Id,
+            Name = deletedItemType.Name,
+            Description = deletedItemType.Description,
+            CreatedAt = deletedItemType.CreatedAt,
+            UpdatedAt = deletedItemType.UpdatedAt
+            }
+        });
+    }
+
     [HttpGet("{id}")]
     public IActionResult ShowSingle(Guid id)
     {

--- a/api/REST/ItemTypes/.rest
+++ b/api/REST/ItemTypes/.rest
@@ -8,6 +8,11 @@ Content-Type: application/json
 }
 ###
 
+### DELETE ITEM TYPE
+DELETE http://localhost:5000/api/ItemTypes/cc3329d0-6414-45c7-b4d9-a1b9c2c4ba6e
+Content-Type: application/json
+###
+
 ### GET ITEM TYPE BY ID
 GET http://localhost:5000/api/itemtypes/caf0c9e3-0266-4ece-800d-cf4a101f0f69
 Content-Type: application/json

--- a/api/providers/ItemTypesProvider.cs
+++ b/api/providers/ItemTypesProvider.cs
@@ -31,5 +31,17 @@ public class ItemTypesProvider : BaseProvider<ItemType>
         return newItemType;
     }
 
+    public override ItemType? Delete(Guid id)
+    {
+        ItemType? foundItemType = _db.ItemTypes.FirstOrDefault(it => it.Id == id);
+        if (foundItemType == null) return null;
+
+        if (_db.Items.Any(i => i.ItemTypeId == id)) throw new ApiFlowException("The item type has associated items. Please remove these associations before deleting the item type.");
+
+        _db.ItemTypes.Remove(foundItemType);
+        SaveToDBOrFail();
+        return foundItemType;
+    }
+
     protected override void ValidateModel(ItemType model) => _itemTypeValidator.ValidateAndThrow(model);
 }


### PR DESCRIPTION
# Issue
https://project-hr.atlassian.net/browse/INFSCP01-30

## Description
Het is nu mogelijk om een Item Type te verwijderen door een DELETE request te sturen naar /itemtypes/{id}

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Steps to Test
Outline the steps to test or reproduce the PR here.

1. Run de DELETE request in de REST file van item types met de ID van een item type in je DB