### PR TITLE
Infscp01 70 get all items of item type

### DIFF
--- a/api/Controllers/ItemTypesController.cs
+++ b/api/Controllers/ItemTypesController.cs
@@ -1,3 +1,4 @@
+using DTO.Item;
 using DTO.ItemType;
 using Microsoft.AspNetCore.Mvc;
 
@@ -58,4 +59,27 @@ public class ItemTypesController : ControllerBase
         CreatedAt = it.CreatedAt,
         UpdatedAt = it.UpdatedAt
     }).ToList());
+
+    [HttpGet("{itemTypeId}/items")]
+    public IActionResult ShowRelatedItems(Guid itemTypeId) =>
+        Ok(_itemTypesProvider.GetRelatedItemsById(itemTypeId)
+        .Select(i => new ItemResponse
+        {
+            Id = i.Id,
+            Code = i.Code,
+            Description = i.Description,
+            ShortDescription = i.ShortDescription,
+            UpcCode = i.UpcCode,
+            ModelNumber = i.ModelNumber,
+            CommodityCode = i.CommodityCode,
+            UnitPurchaseQuantity = i.UnitPurchaseQuantity,
+            UnitOrderQuantity = i.UnitOrderQuantity,
+            PackOrderQuantity = i.PackOrderQuantity,
+            SupplierReferenceCode = i.SupplierReferenceCode,
+            SupplierPartNumber = i.SupplierPartNumber,
+            ItemGroupId = i.ItemGroupId,
+            ItemLineId = i.ItemLineId,
+            ItemTypeId = i.ItemTypeId,
+            SupplierId = i.SupplierId
+        }).ToList());
 }

--- a/api/REST/ItemTypes/.rest
+++ b/api/REST/ItemTypes/.rest
@@ -18,3 +18,8 @@ GET http://localhost:5000/api/itemtypes
 Content-Type: application/json
 ###
 
+### GET ALL ITEMS FROM ITEM TYPES
+GET http://localhost:5000/api/itemtypes/db359ddb-1d7c-415c-bd26-a7386f319d4b/items
+Content-Type: application/json
+###
+

--- a/api/providers/ItemTypesProvider.cs
+++ b/api/providers/ItemTypesProvider.cs
@@ -31,5 +31,7 @@ public class ItemTypesProvider : BaseProvider<ItemType>
         return newItemType;
     }
 
+    public List<Item> GetRelatedItemsById(Guid itemTypeId) => _db.Items.Where(i => i.ItemTypeId == itemTypeId).ToList();
+
     protected override void ValidateModel(ItemType model) => _itemTypeValidator.ValidateAndThrow(model);
 }


### PR DESCRIPTION
# Issue
https://project-hr.atlassian.net/browse/INFSCP01-70

## Description
Het is nu mogelijk om via /itemtypes/{itemtype_id}/items alle items op te halen wat behoort bij 1 specifieke item type.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Steps to Test
Outline the steps to test or reproduce the PR here.

1. Maak een nieuwe Item aan met een Item Type ID die je al hebt (of maak een nieuwe als je die niet hebt)
2. Voer deze Item Type ID in bij de GET van /itemtypes/{itemtype_id}/items
3. Check de response