### PR TITLE
Infscp01 59 get all items from item line

### DIFF
--- a/api/Controllers/ItemLinesController.cs
+++ b/api/Controllers/ItemLinesController.cs
@@ -1,3 +1,4 @@
+using DTO.Item;
 using DTO.ItemLine;
 using Microsoft.AspNetCore.Mvc;
 
@@ -94,4 +95,27 @@ public class ItemLinesController : ControllerBase
                 UpdatedAt = foundItemLine.UpdatedAt
             });
     }
+
+    [HttpGet("{itemLineId}/items")]
+    public IActionResult ShowRelatedItems(Guid itemLineId) =>
+        Ok(_itemLinesProvider.GetRelatedItemsById(itemLineId)
+        .Select(i => new ItemResponse
+        {
+            Id = i.Id,
+            Code = i.Code,
+            Description = i.Description,
+            ShortDescription = i.ShortDescription,
+            UpcCode = i.UpcCode,
+            ModelNumber = i.ModelNumber,
+            CommodityCode = i.CommodityCode,
+            UnitPurchaseQuantity = i.UnitPurchaseQuantity,
+            UnitOrderQuantity = i.UnitOrderQuantity,
+            PackOrderQuantity = i.PackOrderQuantity,
+            SupplierReferenceCode = i.SupplierReferenceCode,
+            SupplierPartNumber = i.SupplierPartNumber,
+            ItemGroupId = i.ItemGroupId,
+            ItemLineId = i.ItemLineId,
+            ItemTypeId = i.ItemTypeId,
+            SupplierId = i.SupplierId
+        }).ToList());
 }

--- a/api/REST/ItemLines/.rest
+++ b/api/REST/ItemLines/.rest
@@ -33,3 +33,8 @@ Content-Type: application/json
 GET http://localhost:5000/api/itemlines/04ccd936-c43b-4568-aa5a-b23093c0b8d8
 Content-Type: application/json
 ###
+
+### GET ALL ITEMS FROM ITEM LINES
+GET http://localhost:5000/api/itemlines/cf00599d-e7df-446b-abd7-46830459a864/items
+Content-Type: application/json
+###

--- a/api/providers/ItemLinesProvider.cs
+++ b/api/providers/ItemLinesProvider.cs
@@ -32,6 +32,8 @@ public class ItemLinesProvider : BaseProvider<ItemLine>
         return newItemLine;
     }
 
+    public List<Item> GetRelatedItemsById(Guid itemLineId) => _db.Items.Where(i => i.ItemLineId == itemLineId).ToList();
+
     public override ItemLine? Update(Guid id, BaseDTO updatedValues)
     {
         ItemLineRequest? req = updatedValues as ItemLineRequest;


### PR DESCRIPTION
# Issue
https://project-hr.atlassian.net/browse/INFSCP01-59

## Description
Het is nu mogelijk om alle items op te halen van een specifiek item line

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Steps to Test
Outline the steps to test or reproduce the PR here.

1. Maak een nieuwe Item aan met een Item Line ID die je al hebt (of maak een nieuwe als je die niet hebt)
2. Voer deze Item Line ID in bij de GET van /itemlines/{itemline_id}/items
3. Check de response