### PR TITLE
fix(address): remove code in AddressValidator and add in AddressProvider

### DIFF
--- a/api/Validators/AddressValidator.cs
+++ b/api/Validators/AddressValidator.cs
@@ -22,15 +22,5 @@ public class AddressValidator : AbstractValidator<Address>
         RuleFor(address => address.CountryCode)
             .NotNull().WithMessage("country_code is required.")
             .NotEmpty().WithMessage("country_code cannot be empty.");
-        RuleFor(address => address.Id)
-            .Custom((addressId, context) =>
-            {
-                if (db.Warehouses.Any(w => w.AddressId == addressId) ||
-                    db.Clients.Any(c => c.AddressId == addressId) ||
-                    db.Suppliers.Any(s => s.AddressId == addressId))
-                {
-                    context.AddFailure("address_id", "The provided address_id is in use and cannot be modified.");
-                }
-            });
     }
 }

--- a/api/providers/AddressProvider.cs
+++ b/api/providers/AddressProvider.cs
@@ -46,7 +46,12 @@ public class AddressProvider : BaseProvider<Address>
         Address? foundAddress = _db.Addresses.FirstOrDefault(a => a.Id == id);
         if (foundAddress == null) return null;
 
-        ValidateModel(foundAddress);
+        if (_db.Warehouses.Any(w => w.AddressId == id) ||
+                    _db.Clients.Any(c => c.AddressId == id) ||
+                    _db.Suppliers.Any(s => s.AddressId == id))
+                {
+                    throw new ApiFlowException($"{id} The provided address_id is in use and cannot be modified.");
+                }
 
         _db.Addresses.Remove(foundAddress);
         SaveToDBOrFail();


### PR DESCRIPTION
# Issue
https://project-hr.atlassian.net/browse/INFSCP01-280

## Description
Je kunt nu een address_id verwijderen behalve als die word gebruikt in Warehouses Clients en of Suppliers.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Steps to _[...Test or Reproduce]_
Outline the steps to test or reproduce the PR here.

1. Run de Delete methode in de .REST file /Addresses

## Related PRs
n.v.t.