### PR TITLE
Infscp01 323 fix transfer with multiple items

### DIFF
--- a/api/Controllers/InventoriesController.cs
+++ b/api/Controllers/InventoriesController.cs
@@ -20,7 +20,7 @@ public class InventoriesController : ControllerBase
         }
 
         Inventory? newInventory = _inventoriesProvider.Create(req);
-        if (newInventory == null) throw new ApiFlowException("Saving new inventory failed.");
+        if (newInventory == null) throw new ApiFlowException("Inventory not found", StatusCodes.Status404NotFound);
 
         return Ok(
             new
@@ -54,7 +54,7 @@ public class InventoriesController : ControllerBase
     public IActionResult Update(Guid id, [FromBody] InventoryRequest req)
     {
         Inventory? updatedInventory = _inventoriesProvider.Update(id, req);
-        if (updatedInventory == null) throw new ApiFlowException("Update inventory failed.");
+        if (updatedInventory == null) throw new ApiFlowException("Inventory not found", StatusCodes.Status404NotFound);
 
         return Ok(
             new

--- a/api/Controllers/TransfersController.cs
+++ b/api/Controllers/TransfersController.cs
@@ -176,25 +176,29 @@ public class TransfersController : ControllerBase
         Transfer? foundTransfer = _transferProvider.GetById(transferId);
         if (foundTransfer == null) return NotFound(new { message = $"Transfer not found for id '{transferId}'" });
 
-        Item? item = _transferProvider.GetItemsFromTransfer(foundTransfer);
-        return Ok(new ItemResponse
-        {
-            Id = item.Id,
-            Code = item.Code,
-            Description = item.Description,
-            ShortDescription = item.ShortDescription,
-            UpcCode = item.UpcCode,
-            ModelNumber = item.ModelNumber,
-            CommodityCode = item.CommodityCode,
-            UnitPurchaseQuantity = item.UnitPurchaseQuantity,
-            UnitOrderQuantity = item.UnitOrderQuantity,
-            PackOrderQuantity = item.PackOrderQuantity,
-            SupplierReferenceCode = item.SupplierReferenceCode,
-            SupplierPartNumber = item.SupplierPartNumber,
-            ItemGroupId = item.ItemGroupId,
-            ItemLineId = item.ItemLineId,
-            ItemTypeId = item.ItemTypeId,
-            SupplierId = item.SupplierId,
-        });
+        List<Item> items = _transferProvider.GetItemsFromTransfer(foundTransfer);
+        return Ok(
+            items.Select(item =>
+            new ItemResponse
+            {
+                Id = item.Id,
+                Code = item.Code,
+                Description = item.Description,
+                ShortDescription = item.ShortDescription,
+                UpcCode = item.UpcCode,
+                ModelNumber = item.ModelNumber,
+                CommodityCode = item.CommodityCode,
+                UnitPurchaseQuantity = item.UnitPurchaseQuantity,
+                UnitOrderQuantity = item.UnitOrderQuantity,
+                PackOrderQuantity = item.PackOrderQuantity,
+                SupplierReferenceCode = item.SupplierReferenceCode,
+                SupplierPartNumber = item.SupplierPartNumber,
+                ItemGroupId = item.ItemGroupId,
+                ItemLineId = item.ItemLineId,
+                ItemTypeId = item.ItemTypeId,
+                SupplierId = item.SupplierId,
+                CreatedAt = item.CreatedAt,
+                UpdatedAt = item.UpdatedAt,
+            }));
     }
 }

--- a/api/Validators/TransferValidator.cs
+++ b/api/Validators/TransferValidator.cs
@@ -6,6 +6,9 @@ public class TransferValidator : AbstractValidator<Transfer>
     {
         RuleFor(transfer => transfer).Custom((transfer, context) =>
         {
+
+            if (transfer.TransferItems == null || transfer.TransferItems.Count == 0) return;
+
             // check if transfer_from and transfer_to are not the same
             if (transfer.TransferFromId == transfer.TransferToId)
             {
@@ -13,8 +16,7 @@ public class TransferValidator : AbstractValidator<Transfer>
                 return;
             }
 
-            if (transfer.TransferItems == null || transfer.TransferItems.Count == 0) return;
-
+            int? totalAmount = null;
             bool fromDock = transfer.TransferFromId == null;
             bool toDock = transfer.TransferToId == null;
 
@@ -29,6 +31,7 @@ public class TransferValidator : AbstractValidator<Transfer>
                 Location? locationFrom = locationsProvider.GetById(id: transfer.TransferFromId.Value, includeWarehouse: true);
                 if (locationFrom == null) return;
                 warehouseFrom = locationFrom.Warehouse;
+                warehouseTo = locationFrom.Warehouse;
                 if (warehouseFrom == null)
                 {
                     context.AddFailure("transfer_from_id", $"Warehouse not found");
@@ -40,6 +43,7 @@ public class TransferValidator : AbstractValidator<Transfer>
             {
                 Location? locationTo = locationsProvider.GetById(id: transfer.TransferToId.Value, includeWarehouse: true);
                 if (locationTo == null) return;
+                warehouseFrom = locationTo.Warehouse;
                 warehouseTo = locationTo.Warehouse;
 
                 if (warehouseTo == null)
@@ -49,10 +53,20 @@ public class TransferValidator : AbstractValidator<Transfer>
                 }
             }
 
+            if(warehouseFrom ==null && warehouseTo == null){
+                context.AddFailure("transfer_from_id and transfer_to_id", $"Warehouse not dock not found for transfer_from_id and transfer_to_id");
+                return;
+            }
+
             if (fromLocation && toLocation && warehouseFrom.Id != warehouseTo.Id)
             {
                 context.AddFailure("transfer_from_id and transfer_to_id", $"Both locations must be in the same warehouse");
                 return;
+            }
+
+            if (fromDock || toDock)
+            {
+                totalAmount = transfer.TransferItems.Sum(i => i.Amount);
             }
 
             foreach (TransferItem transferItem in transfer.TransferItems)
@@ -68,54 +82,41 @@ public class TransferValidator : AbstractValidator<Transfer>
                     return;
                 }
 
+                Guid currentInventoryId = foundInventory.Id;
+
                 if (fromLocation)
                 {
-                    // check if the inventory_id is on the location (from_transfer_id)
-                    Location? locationOfTransferFrom = db.Locations.FirstOrDefault(l => l.Id == transfer.TransferFromId);
+                    // check if the item.inventoryId is on the location (from_transfer_id)
+                    InventoryLocation? locationOfTransferFrom = db.InventoryLocations.FirstOrDefault(il => 
+                        il.InventoryId == currentInventoryId && 
+                        il.LocationId == transfer.TransferFromId
+                    );
+
+                    // returns error if the given inventoryId is not found with the corresponding location of from_transfer_id
                     if (locationOfTransferFrom == null)
                     {
-                        context.AddFailure("items", $"item is not from this location {transfer.TransferFromId}");
+                        context.AddFailure("transfer_from", $"item_id {itemId} not found on the specified location of transfer_from_id {transfer.TransferFromId}");
                         return;
                     }
 
                     // check if the selected on_hand amount is lower or equal to the selected amount
                     int? transferAmount = transferItem.Amount;
-                    // if (transferAmount > locationOfTransferFrom.OnHand)
-                    // {
-                    //     context.AddFailure("items", "The transfer amount exceeds the available inventory at the source location. Please adjust the amount to match the on-hand quantity.");
-                    //     return;
-                    // }
-                }
-
-                if (toLocation)
-                {
-                    // get inventory_id from location
-                    Location? transferToLocation = db.Locations.FirstOrDefault(l => l.Id == transfer.TransferToId);
-                    if (transferToLocation == null) return;
-
-                    // if inventory_id is different from the item.InventoryId then show exception.
-                    // if (transferToLocation.InventoryId.HasValue && foundInventory?.Id != transferToLocation.InventoryId)
-                    // {
-                    //     context.AddFailure("items", $"There already is another item on this location {transfer.TransferToId}");
-                    //     return;
-                    // }
-                }
-
-                int? totalAmount = null;
-                if (fromDock || toDock)
-                {
-                    totalAmount = transfer.TransferItems.Sum(i => i.Amount);
+                    if (locationOfTransferFrom.OnHandAmount < transferAmount)
+                    {
+                        context.AddFailure("items", "The transfer amount exceeds the available inventory at the source location. Please adjust the amount to match the on-hand quantity.");
+                        return;
+                    }
                 }
 
                 if (fromDock)
                 {
                     // Find the item in the destination dock
-                    DockItem fromDockItem = db.DockItems.FirstOrDefault(di => di.DockId == warehouseTo.Dock.Id && di.ItemId == itemId);
+                    DockItem? fromDockItem = db.DockItems.FirstOrDefault(di => di.DockId == warehouseFrom.Dock.Id && di.ItemId == itemId);
 
                     // Validate item existence in the dock
                     if (fromDockItem == null)
                     {
-                        context.AddFailure("items", $"Item not in dock");
+                        context.AddFailure("items", $"Item {itemId} not found in dock of warehouse {warehouseFrom.Id}");
                         return;
                     }
 
@@ -138,7 +139,7 @@ public class TransferValidator : AbstractValidator<Transfer>
 
                     if (totalAmount > spaceAvailable)
                     {
-                        context.AddFailure("items", $"The selected amount exceeds the dock's capacity. The maximum capacity is 50, with only {spaceAvailable} space(s) remaining. You attempted to add {totalAmount} item(s). Please adjust the quantity to fit within the available space.");
+                        context.AddFailure("items", $"The selected amount exceeds the dock's capacity. The maximum capacity is {Dock.CAPCITY}, with only {spaceAvailable} space(s) remaining. You attempted to add {totalAmount} item(s). Please adjust the quantity to fit within the available space.");
                         return;
                     }
                 }
@@ -153,7 +154,7 @@ public class TransferValidator : AbstractValidator<Transfer>
             {
                 if (TransferFromId.HasValue && !db.Locations.Any(l => l.Id == TransferFromId))
                 {
-                    context.AddFailure("transfer_from_id", "The provided transfer_from_id does not exist.");
+                    context.AddFailure("transfer_from_id", "The provided location of transfer_from_id does not exist.");
                 }
             });
 
@@ -162,7 +163,7 @@ public class TransferValidator : AbstractValidator<Transfer>
             {
                 if (TransferToId.HasValue && !db.Locations.Any(l => l.Id == TransferToId))
                 {
-                    context.AddFailure("transfer_to_id", "The provided transfer_to_id does not exist.");
+                    context.AddFailure("transfer_to_id", "The provided location of transfer_to_id does not exist.");
                 }
             });
 

--- a/api/providers/LocationsProvider.cs
+++ b/api/providers/LocationsProvider.cs
@@ -9,17 +9,16 @@ public class LocationsProvider : BaseProvider<Location>
         _locationValidator = locationValidator;
     }
 
-    private IQueryable<Location> GetLocationByIdQuery(bool includeWarehouse = false, bool includeInventory = false)
+    private IQueryable<Location> GetLocationByIdQuery(bool includeWarehouse = false)
     {
         IQueryable<Location> query = _db.Locations.AsQueryable();
         if (includeWarehouse) query = query.Include(l => l.Warehouse);
-        // if (includeInventory) query = query.Include(l => l.Inventory);
         return query;
     }
 
     public override Location? GetById(Guid id) => GetLocationByIdQuery().FirstOrDefault(l => l.Id == id);
 
-    public Location? GetById(Guid id, bool includeWarehouse = false, bool includeInventory = false) => GetLocationByIdQuery(includeWarehouse, includeInventory).FirstOrDefault(l => l.Id == id);
+    public Location? GetById(Guid id, bool includeWarehouse = false) => GetLocationByIdQuery(includeWarehouse).FirstOrDefault(l => l.Id == id);
 
     public override List<Location>? GetAll() => _db.Locations.ToList();
 

--- a/api/providers/TransfersProvider.cs
+++ b/api/providers/TransfersProvider.cs
@@ -89,8 +89,10 @@ public class TransferProvider : BaseProvider<Transfer>
     public Transfer? CommitTransfer(Guid transferId)
     {
         Transfer? foundTransfer = GetById(transferId) ?? throw new ApiFlowException($"Transfer with ID {transferId} does not exist.", StatusCodes.Status404NotFound);
+
         if (foundTransfer.TransferStatus == TransferStatus.Completed)
-            throw new ApiFlowException("This transfer has already been commited.", StatusCodes.Status409Conflict);
+            throw new ApiFlowException(message: "This transfer has already been commited.", StatusCodes.Status409Conflict);
+
 
         ValidateModel(foundTransfer);
 
@@ -103,81 +105,97 @@ public class TransferProvider : BaseProvider<Transfer>
             bool isFromDock = !isFromLocation;
             bool isToDock = !isToLocation;
 
-            Location? fromLocation = null;
-            Location? toLocation = null;
-            Dock? dock = null;
-            DockItem? dockItem = null;
+            Location? fromLocation = isFromLocation
+                ? _locationsProvider.GetById(foundTransfer.TransferFromId.Value, includeWarehouse: true)
+                : null;
 
-            TransferItem? firstItem = foundTransfer.TransferItems.First();
-            Inventory? ItemInventory = _inventoriesProvider.GetInventoryByItemId(itemId: firstItem.ItemId.Value); // because all items are the same always take the first one
+            Location? toLocation = isToLocation
+                ? _locationsProvider.GetById(foundTransfer.TransferToId.Value, includeWarehouse: true)
+                : null;
 
+            Dock? dock = fromLocation?.Warehouse?.Dock ?? toLocation?.Warehouse?.Dock;
 
-            if (isFromLocation)
+            List<DockItem>? dockItems = (isFromDock || isToDock)
+                ? _db.DockItems.Where(di => di.DockId == dock.Id).ToList()
+                : null;
+
+            foreach (TransferItem transferItem in foundTransfer.TransferItems)
             {
-                fromLocation = _locationsProvider.GetById(foundTransfer.TransferFromId.Value, includeWarehouse: true, includeInventory: true);
-                dock = fromLocation.Warehouse.Dock;
-            }
-            if (isToLocation)
-            {
-                toLocation = _locationsProvider.GetById(foundTransfer.TransferToId.Value, includeWarehouse: true, includeInventory: true);
-                if (dock == null) dock = toLocation.Warehouse.Dock;
-            }
+                Guid? currentItemId = transferItem.ItemId;
+                Inventory? currentItemInventory = _inventoriesProvider.GetInventoryByItemId(itemId: currentItemId);
+                DockItem? itemInDock = (isFromDock || isToDock) ? _db.DockItems.FirstOrDefault(d => d.ItemId == currentItemId) : null;
 
-            if (isFromDock || isToDock)
-            {
-                dockItem = _db.DockItems.FirstOrDefault(di => di.DockId == dock.Id && di.ItemId == firstItem.ItemId);
-            }
-
-            int? totalAmount = foundTransfer.TransferItems.Sum(i => i.Amount);
-
-            if (isFromLocation)
-            {
-                // fromLocation.OnHand -= totalAmount;
-            }
-
-            if (isToLocation)
-            {
-                // if inventory_id is empty set inventory_id with on_hand
-                // if (!toLocation.InventoryId.HasValue) toLocation.InventoryId = ItemInventory.Id;
-
-                // if inventory_id is the same inventory_id as item then increment on_hand amount
-                // toLocation.OnHand = (toLocation.OnHand ?? 0) + totalAmount;
-            }
-
-            if (isToDock)
-            {
-                // create or increment the item that is going to be at DockItem
-                if (dockItem == null)
+                if (isFromLocation)
                 {
-                    DockItem newDockItem = new(newInstance: true)
+                    InventoryLocation? inventoryLocation = _db.InventoryLocations.FirstOrDefault(il => il.InventoryId == currentItemInventory.Id && il.LocationId == foundTransfer.TransferFromId);
+                    inventoryLocation.OnHandAmount -= transferItem.Amount.Value;
+                }
+
+                if (isToLocation)
+                {
+                    // the inventory location for tranfer_to_id
+                    InventoryLocation? foundInventoryLocationTo = _db.InventoryLocations.FirstOrDefault(il => il.LocationId == foundTransfer.TransferToId);
+
+                    // if the item does not exist on the transfer_to location then create a new inventoryLocation with the item
+                    if (foundInventoryLocationTo == null)
                     {
-                        ItemId = firstItem.ItemId,
-                        DockId = dock.Id,
-                        Amount = totalAmount
-                    };
-                    _db.DockItems.Add(newDockItem);
+                        _db.InventoryLocations.Add(new InventoryLocation(newInstance: true)
+                        {
+                            InventoryId = currentItemInventory.Id,
+                            LocationId = foundTransfer.TransferToId,
+                            OnHandAmount = transferItem.Amount.Value
+                        });
+                    }
+                    else // if the item does exist on on the transfer_to location then increment the onHandAmount
+                    {
+                        foundInventoryLocationTo.OnHandAmount += transferItem.Amount.Value;
+                        foundInventoryLocationTo.SetUpdatedAt();
+                        _db.InventoryLocations.Update(foundInventoryLocationTo);
+                    }
+
                 }
-                else
+
+                // create or increment the item that is going to be at DockItem
+                if (isToDock)
                 {
-                    dockItem.Amount += totalAmount;
-                    dockItem.SetUpdatedAt();
+                    // if not found create dockitem
+                    if (itemInDock == null)
+                    {
+                        _db.DockItems.Add(new DockItem(newInstance: true)
+                        {
+                            ItemId = currentItemId,
+                            DockId = dock.Id,
+                            Amount = transferItem.Amount
+                        });
+                    }
+                    else
+                    {
+                        // if found increment
+                        itemInDock.Amount += transferItem.Amount;
+                        _db.DockItems.Update(itemInDock);
+                    }
+                }
+
+
+                // remove or decrement the item that is going to be removed from dock
+                if (isFromDock)
+                {
+                    itemInDock.Amount -= transferItem.Amount;
+
+                    if (itemInDock.Amount == 0)
+                    {
+                        _db.DockItems.Remove(itemInDock);
+                    }
+                    else
+                    {
+                        itemInDock.SetUpdatedAt();
+                        _db.DockItems.Update(itemInDock);
+                    }
                 }
             }
-
-            // remove or decrement the item that is going to be removed from dock
-            if (isFromDock)
-            {
-                dockItem.Amount -= totalAmount;
-                if (dockItem.Amount == null)
-                    dockItem.SetUpdatedAt();
-                _db.DockItems.Remove(dockItem);
-            }
-
             foundTransfer.TransferStatus = TransferStatus.Completed;
             SaveToDBOrFail();
             transaction.Commit();
-
-
             return foundTransfer;
         }
         catch (Exception)
@@ -185,12 +203,13 @@ public class TransferProvider : BaseProvider<Transfer>
             transaction.Rollback();
             throw;
         }
+
     }
 
     public Item? GetItemsFromTransfer(Transfer transfer)
     {
         Guid? itemId = transfer.TransferItems.First().ItemId;
-        return _itemsProvider.GetById((Guid)itemId);
+        return _itemsProvider.GetById(itemId.Value);
     }
 
     public bool IsTransferCompleted(Guid transferId) => _db.Transfers.Any(t => t.Id == transferId && t.TransferStatus == TransferStatus.Completed);

--- a/api/providers/TransfersProvider.cs
+++ b/api/providers/TransfersProvider.cs
@@ -206,10 +206,10 @@ public class TransferProvider : BaseProvider<Transfer>
 
     }
 
-    public Item? GetItemsFromTransfer(Transfer transfer)
+    public List<Item> GetItemsFromTransfer(Transfer transfer)
     {
-        Guid? itemId = transfer.TransferItems.First().ItemId;
-        return _itemsProvider.GetById(itemId.Value);
+        List<Guid?> itemIds = transfer.TransferItems.Select(ti => ti.ItemId).ToList();
+        return _db.Items.Where(i => itemIds.Contains(i.Id)).ToList();
     }
 
     public bool IsTransferCompleted(Guid transferId) => _db.Transfers.Any(t => t.Id == transferId && t.TransferStatus == TransferStatus.Completed);


### PR DESCRIPTION
# Issue
https://project-hr.atlassian.net/browse/INFSCP01-323

## Description

Het systeem biedt nu de mogelijkheid om meerdere items van bijvoorbeeld `locatie A` naar `locatie B` te verplaatsen binnen hetzelfde warehouse. De verwachte werking is als volgt:

- De gekozen items moeten daadwerkelijk afkomstig zijn van de opgegeven `transfer_from_id` (oftewel `locatie A`).
- De gekozen hoeveelheid per item mag niet hoger zijn dan de beschikbare `on_hand` voorraad op die locatie.

### Scenario 1
**Locatie A → Locatie B**  
Verplaats meerdere items van `locatie A` naar `locatie B`. Er zijn geen beperkingen op het aantal items dat per locatie kan worden opgeslagen.

### Scenario 2
**Locatie A → Dock (null)**  
Verplaats meerdere items van `locatie A` naar de `Dock`. De Dock bevindt zich in hetzelfde warehouse als `locatie A`. De maximale opslagcapaciteit van de Dock is **50**.

### Scenario 3
**Dock (null) → Locatie A**  
Verplaats meerdere items van de `Dock` naar `locatie A`. De Dock bevindt zich in hetzelfde warehouse als `locatie A`. De hoeveelheid te verplaatsen items mag niet hoger zijn dan wat er daadwerkelijk op de Dock beschikbaar is.

### Database tabellen waar je moet opletten
| DB Tables|
|--------|
| Transfers|
| TransferItems |
| Dock|
| DockItems| 
|Inventory|
|InventoryLocations|


## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Steps to Test

1. Voer benodigde migrations uit (indien nodig)
2. Alle endpoints van de `Transfers.rest` file uitvoeren op basis van de beschrijving.

## Related PRs
n.v.t

branch | PR
n.v.t