### PR TITLE
feature(CD pipeline): Added dotnet publish job to generate self-conta…

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -93,3 +93,8 @@ jobs:
         run: dotnet restore
       - name: Dotnet publish
         run: dotnet publish -c Release -r linux-x64 --self-contained -o ./release
+      - name: Upload Linux x64 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-x64-artifact
+          path: ./release

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -79,4 +79,17 @@ jobs:
       - name: Add Coverage Report to Summary
         run: cat api.Tests/Report/SummaryGithub.md >> $GITHUB_STEP_SUMMARY  
 
-          
+  dotnet_publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: test_and_code_coverage
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Dotnet publish
+        run: dotnet publish -c Release -r linux-x64 --self-contained -o ./release

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - development
+      - release
   pull_request:
     branches:
       - main
@@ -83,6 +84,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     needs: test_and_code_coverage
+    if: ${{ github.ref_name == 'release' }} 
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET


### PR DESCRIPTION
# Issue
https://project-hr.atlassian.net/browse/INFSCP01-295

## Description
Er is een job toegevoegd aan de CD-pipeline om een self-contained linux x64 artifact te maken. Dit is mogelijk via de dotnet publish command die is toegevoegd. Deze artifact wordt opgeslagen in een map genaamd /release. De upload artifact voor GitHub moet nog gemaakt worden hiervoor.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Steps to Test
Outline the steps to test or reproduce the PR here.

1. Push of pull naar deze branch en zie in Github Actions de pipeline uitgevoerd worden.