### PR TITLE
feature(shipment): show orders of specific shipment

### DIFF
--- a/api.IntegrationTests/Seeding.cs
+++ b/api.IntegrationTests/Seeding.cs
@@ -222,7 +222,7 @@ namespace api.IntegrationTests
                 {
                     Id = Guid.Parse("7ffe0c5e-c188-47a4-9dcf-f3e17c2ff41c"),
                     OrderDate = DateTime.UtcNow,
-                    OrderStatus = "Pending",
+                    OrderStatus = OrderStatus.Pending,
                     WarehouseId = Guid.Parse("8798e409-e0b5-4575-a95d-2d8136d595ec"),
                     BillToClientId = Guid.Parse("68b7ef68-b6a7-45de-a6f8-7656b7af44b7"),
                     OrderItems = new List<OrderItem>

--- a/api/Controllers/ShipmentsController.cs
+++ b/api/Controllers/ShipmentsController.cs
@@ -1,3 +1,4 @@
+using DTO.Order;
 using DTO.Shipment;
 using Microsoft.AspNetCore.Mvc;
 
@@ -236,5 +237,35 @@ public class ShipmentsController : ControllerBase
                 }
             }
         );
+    }
+
+    [HttpGet("{shipmentId}/orders")]
+    public IActionResult GetOrderByShipment(Guid shipmentId)
+    {
+        return Ok(_shipmentProvider.GetOrdersByShipment(shipmentId)?.Select(o => new OrderResponse
+        {
+            Id = o.Id,
+            OrderDate = o.OrderDate,
+            RequestDate = o.RequestDate,
+            Reference = o.Reference,
+            ReferenceExtra = o.ReferenceExtra,
+            OrderStatus = o.OrderStatus,
+            Notes = o.Notes,
+            PickingNotes = o.PickingNotes,
+            TotalAmount = o.TotalAmount,
+            TotalDiscount = o.TotalDiscount,
+            TotalTax = o.TotalTax,
+            TotalSurcharge = o.TotalSurcharge,
+            WarehouseId = o.WarehouseId,
+            ShipToClientId = o.ShipToClientId,
+            BillToClientId = o.BillToClientId,
+            CreatedAt = o.CreatedAt,
+            UpdatedAt = o.UpdatedAt,
+            Items = o.OrderItems?.Select(oi => new OrderItemRequest
+            {
+                ItemId = oi.ItemId,
+                Amount = oi.Amount
+            }).ToList()
+        }).ToList());
     }
 }

--- a/api/REST/Shipments.rest
+++ b/api/REST/Shipments.rest
@@ -18,9 +18,13 @@ Content-Type: application/json
   "total_package_weight": 3.4,
   "items": [
     {
-      "item_id": "fae716d1-5649-4e26-a56c-12a8679e9629",
-      "amount": 5
+      "item_id": "dac06dda-eda1-4557-8eef-e4b0b0545ae7",
+      "amount": 51
     }
+  ],
+  "orders": [
+    "4b8273b8-535b-4378-87e1-852a5adab5d8",
+    "e495587e-f200-4633-ae88-563612d57d11"
   ]
 }
 ###
@@ -75,4 +79,10 @@ Content-Type: application/json
 
 ### COMMIT SHIPMENT (change ID to the ID in your database)
 PUT http://localhost:5000/api/shipments/ef2bb6bb-8865-4fc1-b009-c2e9b848daec/commit
+Content-Type: application/json
+###
+
+
+### Get orders from shipment (change ID to the ID in your database)
+GET http://localhost:5000/api/shipments/86335c30-65ab-4854-ace1-d6a56bca36fd/orders
 Content-Type: application/json

--- a/api/providers/ShipmentProvider.cs
+++ b/api/providers/ShipmentProvider.cs
@@ -182,5 +182,15 @@ public class ShipmentProvider : BaseProvider<Shipment>
         return shipment;
     }
 
+    public List<Order?>? GetOrdersByShipment(Guid shipmentId)
+    {
+        return _db.OrderShipments
+          .Where(os => os.ShipmentId == shipmentId)
+          .Include(os => os.Order)
+          .ThenInclude(o => o.OrderItems)
+          .Select(os => os.Order)
+          .ToList();
+    }
+
     protected override void ValidateModel(Shipment model) => _shipmentValidator.ValidateAndThrow(model);
 }


### PR DESCRIPTION
# Issue
https://project-hr.atlassian.net/browse/INFSCP01-80

## Description
Toont de lijst van orders die gekoppeld zijn aan een specifieke shipment.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Steps to Test

1. Voer de `Shipments.Rest` file uit met de endpoint shipments/{id}/orders.

## Related PRs
n.v.t

branch | PR
n.v.t