### PR TITLE
feature(shipment):  update assigned orders to a specific shipment

### DIFF
--- a/api/Controllers/ShipmentsController.cs
+++ b/api/Controllers/ShipmentsController.cs
@@ -338,4 +338,43 @@ public class ShipmentsController : ControllerBase
             Orders = updatedShipment?.OrderShipments?.Select(os => os.OrderId)?.ToList()
         });
     }
+
+    [HttpPut("{shipmentId}/orders")]
+    public IActionResult UpdateShipmentOrders(Guid shipmentId, [FromBody] List<Guid?> reqOrderIds)
+    {
+        Shipment? foundShipment = _shipmentProvider.GetById(shipmentId);
+        if (foundShipment == null) throw new ApiFlowException($"Shipment not found for id '{shipmentId}'", StatusCodes.Status404NotFound);
+
+        if (foundShipment.ShipmentStatus == ShipmentStatus.Delivered)
+        {
+            throw new ApiFlowException("This shipment has already been delivered. Updates are not allowed.", StatusCodes.Status409Conflict);
+        }
+
+        Shipment? updatedShipment = _shipmentProvider.UpdateShipmentOrders(foundShipment, reqOrderIds);
+        return Ok(new ShipmentResponse
+        {
+            Id = updatedShipment.Id,
+            OrderDate = updatedShipment.OrderDate,
+            RequestDate = updatedShipment.RequestDate,
+            ShipmentDate = updatedShipment.ShipmentDate,
+            ShipmentType = updatedShipment.ShipmentType.ToString(),
+            ShipmentStatus = updatedShipment.ShipmentStatus.ToString(),
+            Notes = updatedShipment.Notes,
+            CarrierCode = updatedShipment.CarrierCode,
+            CarrierDescription = updatedShipment.CarrierDescription,
+            ServiceCode = updatedShipment.ServiceCode,
+            PaymentType = updatedShipment.PaymentType.ToString(),
+            TransferMode = updatedShipment.TransferMode.ToString(),
+            TotalPackageCount = updatedShipment.TotalPackageCount,
+            TotalPackageWeight = updatedShipment.TotalPackageWeight,
+            CreatedAt = updatedShipment.CreatedAt,
+            UpdatedAt = updatedShipment.UpdatedAt,
+            Items = updatedShipment.ShipmentItems?.Select(item => new ShipmentItemRR
+            {
+                ItemId = item.ItemId,
+                Amount = item.Amount
+            }).ToList(),
+            Orders = updatedShipment?.OrderShipments?.Select(os => os.OrderId)?.ToList()
+        });
+    }
 }

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -154,7 +154,7 @@ builder.Services.AddScoped<IValidator<Dock>, DockValidator>();
 builder.Services.AddScoped<IValidator<WarehouseRequest>, WarehouseRequestValidator>();
 builder.Services.AddScoped<IValidator<ShipmentRequest>, ShipmentRequestValidator>();
 builder.Services.AddScoped<IValidator<OrderRequest>, OrderRequestValidator>();
-builder.Services.AddScoped<IValidator<UpdateShipmentItemDTO>, ShipmentItemRequestValidator>();
+builder.Services.AddScoped<IValidator<UpdateShipmentItemDTO>, UpdateShipmentRequestValidation>();
 
 
 builder.Services.AddControllers().AddJsonOptions(options =>

--- a/api/REST/Shipments.rest
+++ b/api/REST/Shipments.rest
@@ -104,3 +104,10 @@ Content-Type: application/json
     }
 ]
 ###
+
+### UPDATE orders from shipment (change ID to the ID in your database)
+PUT http://localhost:5000/api/shipments/6efdee99-e458-45a3-840e-042bf39241d1/orders
+Content-Type: application/json
+
+[]
+###

--- a/api/Validators/UpdateShipmentRequestValidation.cs
+++ b/api/Validators/UpdateShipmentRequestValidation.cs
@@ -46,7 +46,7 @@ public class UpdateShipmentRequestValidation : AbstractValidator<UpdateShipmentI
                 }
             }
         });
-        
+
         // Validation to check if item is in DB is in ShipmentValidation
         RuleFor(req => req.Orders)
            .Custom((orders, context) =>

--- a/api/providers/ShipmentProvider.cs
+++ b/api/providers/ShipmentProvider.cs
@@ -10,7 +10,7 @@ public class ShipmentProvider : BaseProvider<Shipment>
     private IValidator<ShipmentRequest> _shipmentRequestValidator;
     private IValidator<UpdateShipmentItemDTO> _updateShipmentRequestValidation;
 
-    public ShipmentProvider(AppDbContext db, IValidator<Shipment> validator, IValidator<ShipmentRequest> shipmentRequestValidator, IValidator<UpdateShipmentItemDTO> updateShipmentRequestValidation ) : base(db)
+    public ShipmentProvider(AppDbContext db, IValidator<Shipment> validator, IValidator<ShipmentRequest> shipmentRequestValidator, IValidator<UpdateShipmentItemDTO> updateShipmentRequestValidation) : base(db)
     {
         _shipmentValidator = validator;
         _shipmentRequestValidator = shipmentRequestValidator;

--- a/api/providers/ShipmentProvider.cs
+++ b/api/providers/ShipmentProvider.cs
@@ -8,13 +8,13 @@ public class ShipmentProvider : BaseProvider<Shipment>
 {
     private IValidator<Shipment> _shipmentValidator;
     private IValidator<ShipmentRequest> _shipmentRequestValidator;
-    private IValidator<UpdateShipmentItemDTO> _shipmentItemRequestValidator;
+    private IValidator<UpdateShipmentItemDTO> _updateShipmentRequestValidation;
 
-    public ShipmentProvider(AppDbContext db, IValidator<Shipment> validator, IValidator<ShipmentRequest> shipmentRequestValidator, IValidator<UpdateShipmentItemDTO> shipmentItemRequestValidator) : base(db)
+    public ShipmentProvider(AppDbContext db, IValidator<Shipment> validator, IValidator<ShipmentRequest> shipmentRequestValidator, IValidator<UpdateShipmentItemDTO> updateShipmentRequestValidation ) : base(db)
     {
         _shipmentValidator = validator;
         _shipmentRequestValidator = shipmentRequestValidator;
-        _shipmentItemRequestValidator = shipmentItemRequestValidator;
+        _updateShipmentRequestValidation = updateShipmentRequestValidation;
     }
 
     public override Shipment? GetById(Guid id) =>
@@ -212,7 +212,7 @@ public class ShipmentProvider : BaseProvider<Shipment>
             Orders = shipment?.OrderShipments?.Select(os => os.OrderId).ToList()
         };
 
-        _shipmentItemRequestValidator.ValidateAndThrow(reqDTO);
+        _updateShipmentRequestValidation.ValidateAndThrow(reqDTO);
 
         using IDbContextTransaction transaction = _db.Database.BeginTransaction();
         try
@@ -224,6 +224,46 @@ public class ShipmentProvider : BaseProvider<Shipment>
                 {
                     ItemId = si.ItemId,
                     Amount = si.Amount
+                }).ToList();
+            }
+
+            ValidateModel(shipment);
+            _db.Shipments.Update(shipment);
+            SaveToDBOrFail();
+            transaction.Commit();
+            return shipment;
+        }
+        catch (Exception)
+        {
+            transaction.Rollback();
+            throw;
+        }
+    }
+
+    public Shipment? UpdateShipmentOrders(Shipment shipment, List<Guid?> reqOrderIds)
+    {
+        var reqDTO = new UpdateShipmentItemDTO()
+        {
+            Items = shipment.ShipmentItems.Select(si => new ShipmentItemRR()
+            {
+                ItemId = si.ItemId,
+                Amount = si.Amount
+            }).ToList(),
+            Orders = reqOrderIds
+        };
+
+
+        _updateShipmentRequestValidation.ValidateAndThrow(reqDTO);
+
+        using IDbContextTransaction transaction = _db.Database.BeginTransaction();
+        try
+        {
+            _db.OrderShipments.RemoveRange(shipment.OrderShipments);
+            if (reqOrderIds.Count() > 0)
+            {
+                shipment.OrderShipments = reqOrderIds.Select(o => new OrderShipment(newInstance: true)
+                {
+                    OrderId = o
                 }).ToList();
             }
 


### PR DESCRIPTION
# Issue
https://project-hr.atlassian.net/browse/INFSCP01-199

## Description
Bij een specefieke shipment kan je de orders vervangen of weghalen

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Steps to Test

1. Voer de rest file uit `Shipments.rest`
2. Op de PUT endpoint /shipments/{id}/orders
3. Request met een body met orderIds
4. Request legen array moet ervoor zorgen dat er geen orders meer worden gekoppeld aan een shipment.

## Related PRs
n.v.t

branch | PR
n.v.t