### PR TITLE
feature(order): show related shipments in order response

### DIFF
--- a/api/Controllers/OrderController.cs
+++ b/api/Controllers/OrderController.cs
@@ -52,7 +52,7 @@ public class OrdersController : ControllerBase
                 {
                     ItemId = oi.ItemId,
                     Amount = oi.Amount
-                }).ToList()
+                }).ToList(),
             }
         });
     }
@@ -93,7 +93,8 @@ public class OrdersController : ControllerBase
                     {
                         ItemId = oi.ItemId,
                         Amount = oi.Amount
-                    }).ToList()
+                    }).ToList(),
+                    Shipments = deletedOrder?.OrderShipments?.Select(os => os.ShipmentId).ToList(),
                 }
             });
     }
@@ -143,7 +144,8 @@ public class OrdersController : ControllerBase
                     {
                         ItemId = oi.ItemId,
                         Amount = oi.Amount
-                    }).ToList()
+                    }).ToList(),
+                    Shipments = updatedOrder?.OrderShipments?.Select(os => os.ShipmentId).ToList(),
                 }
             });
     }
@@ -173,7 +175,8 @@ public class OrdersController : ControllerBase
         {
             ItemId = oi.ItemId,
             Amount = oi.Amount
-        }).ToList()
+        }).ToList(),
+        Shipments = o?.OrderShipments?.Select(os => os.ShipmentId).ToList(),
     }).ToList());
 
     [HttpGet("{id}")]
@@ -208,7 +211,8 @@ public class OrdersController : ControllerBase
                     {
                         ItemId = oi.ItemId,
                         Amount = oi.Amount
-                    }).ToList()
+                    }).ToList(),
+                    Shipments = foundOrder?.OrderShipments?.Select(os => os.ShipmentId).ToList(),
                 }
             );
     }
@@ -269,7 +273,8 @@ public class OrdersController : ControllerBase
                     {
                         ItemId = oi.ItemId,
                         Amount = oi.Amount
-                    }).ToList()
+                    }).ToList(),
+                    Shipments = foundOrder?.OrderShipments?.Select(os => os.ShipmentId).ToList(),
                 }
             }
         );

--- a/api/DTOs/item/OrderDTO.cs
+++ b/api/DTOs/item/OrderDTO.cs
@@ -104,6 +104,9 @@ namespace DTO.Order
         [JsonPropertyName("ship_to_client")]
         public Guid? ShipToClientId { get; set; }
 
+        [JsonPropertyName("shipments")]
+        public List<Guid?>? Shipments { get; set; }
+
         [JsonPropertyName("created_at")]
         public DateTime? CreatedAt { get; set; }
 

--- a/api/Validators/UpdateShipmentRequestValidation.cs
+++ b/api/Validators/UpdateShipmentRequestValidation.cs
@@ -35,7 +35,7 @@ public class UpdateShipmentRequestValidation : AbstractValidator<UpdateShipmentI
                             return;
                         }
 
-                        bool orderIsClosed = db.Orders.Any(o => o.OrderStatus == OrderStatus.Closed);
+                        bool orderIsClosed = db.Orders.Any(o => o.OrderStatus == OrderStatus.Closed && o.Id == orderId);
                         if (orderIsClosed)
                         {
                             context.AddFailure("orders", $"The order with ID {orderId} is closed. Shipments can no longer be assigned to a closed order.");

--- a/api/providers/OrderProvider.cs
+++ b/api/providers/OrderProvider.cs
@@ -20,8 +20,8 @@ public class OrderProvider : BaseProvider<Order>
         _inventoriesProvider = inventoriesProvider;
     }
 
-    public override List<Order>? GetAll() => _db.Orders.Include(o => o.OrderItems).ToList();
-    public override Order? GetById(Guid id) => _db.Orders.Include(o => o.OrderItems).FirstOrDefault(order => order.Id == id);
+    public override List<Order>? GetAll() => _db.Orders.Include(o => o.OrderItems).Include(o => o.OrderShipments).ToList();
+    public override Order? GetById(Guid id) => _db.Orders.Include(o => o.OrderItems).Include(o => o.OrderShipments).FirstOrDefault(order => order.Id == id);
 
     public List<OrderItem> GetRelatedOrderById(Guid id) => _db.Orders.Where(o => o.Id == id).SelectMany(o => o.OrderItems).ToList();
 
@@ -132,7 +132,7 @@ public class OrderProvider : BaseProvider<Order>
         if (req == null) throw new ApiFlowException("Could not process update order request. Update failed.");
         _orderRequestValidator.ValidateAndThrow(req);
 
-        Order? existingOrder = _db.Orders.Include(o => o.OrderItems).FirstOrDefault(o => o.Id == id);
+        Order? existingOrder = GetById(id);
 
         using IDbContextTransaction transaction = _db.Database.BeginTransaction();
         try


### PR DESCRIPTION
## Description
Het is nu mogelijk om de gerelateerde shipments te zien van een order.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Steps to Test
Outline the steps to test or reproduce the PR here.

1. Voer de rest file `Orders.rest`
2. Check de responses als ze shipments bevatten

## Related PRs
n.v.t

branch | PR
n.v.t